### PR TITLE
Frontend tweaks

### DIFF
--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -33,6 +33,7 @@
     "browser-sync-webpack-plugin": "^2.2.2",
     "file-loader": "^3.0.1",
     "node-sass": "^4.13.0",
+    "prettier": "^2.4.1",
     "react-svg-loader": "^2.1.0",
     "sass-loader": "^8.0.0",
     "scss-loader": "^0.0.1",

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -52,6 +52,7 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-redux": "^7.0.3",
+    "react-responsive": "^9.0.0-beta.4",
     "react-router": "^4.3.1",
     "react-router-dom": "^5.1.2",
     "redux": "^4.0.1",

--- a/web/frontend/src/AlbumCard/Style.scss
+++ b/web/frontend/src/AlbumCard/Style.scss
@@ -1,3 +1,4 @@
+@import "../Vars";
 
 .image-small {
     width: 150px;
@@ -9,6 +10,13 @@
     max-height: 200px;
     width: 100%;
     height: 100%;
+}
+
+@media only screen and (max-width: $mobile-width-limit) {
+    .image-medium {
+        max-width: 180px;
+        max-height: 180px;
+    }
 }
 
 .image-large {

--- a/web/frontend/src/AlbumPage/Component.js
+++ b/web/frontend/src/AlbumPage/Component.js
@@ -22,7 +22,7 @@ const mostCommonValue = (l, k) => (
     || [undefined, undefined]
 )[0];
 
-export default function AlbumPage({album, albumartist}) {
+export default function AlbumPage({album, albumartist, showMessage}) {
 
     const {loaded, err, data} = useMPDQuery(`find albumartist "${albumartist}" album "${album}"`);
     if (!loaded)
@@ -45,10 +45,11 @@ export default function AlbumPage({album, albumartist}) {
     const date = mostCommonValue(tracks, "date");
     const genre = mostCommonValue(tracks, "genre");
 
-    const albumAdd = () => mpdQuery(`findadd album "${album}" albumartist "${albumartist}"`);
+    const albumAdd = () => mpdQuery(`findadd album "${album}" albumartist "${albumartist}"`)
+        .then(() => showMessage("Album added"));
     const trackAdd = track => mpdQuery(
         `findadd album "${album}" albumartist "${albumartist}" track ${track}`
-    );
+    ).then(() => showMessage("Track added"));
 
     return <React.Fragment>
         <h1>{album}</h1>

--- a/web/frontend/src/AlbumPage/Container.js
+++ b/web/frontend/src/AlbumPage/Container.js
@@ -1,0 +1,9 @@
+import {connect} from "react-redux";
+import AlbumPage from "./Component";
+import {Actions} from "../Snackbar";
+
+const mapDispatchToProps = dispatch => ({
+    showMessage: msg => dispatch(Actions.showSnackbar(msg))
+})
+
+export default connect(null, mapDispatchToProps)(AlbumPage);

--- a/web/frontend/src/AlbumPage/Style.scss
+++ b/web/frontend/src/AlbumPage/Style.scss
@@ -1,19 +1,6 @@
 
 @import "../Vars";
 
-.addAlbum {
-    background: $color-button;
-    color: white;
-    border: none;
-    font-size: 1.1rem;
-    border-radius: 2px;
-    padding: 7px;
-    cursor: pointer;
-    &:hover {
-        background: $color-button-hover;
-    }
-}
-
 .trackItem {
     padding: 6px;
     background: $color-list-item;
@@ -28,28 +15,22 @@
 
     button {
         position: absolute;
-        font-weight: bold;
         top: 0;
         right: 0;
         height: 100%;
-        border-radius: 4px;
-        border: none;
-        background: $color-button;
-        color: white;
         display: none;
-        cursor: pointer;
-
-        &:hover {
-            background: $color-button-hover;
-        }
     }
     &:hover button {
         display: inline-block;
     }
 }
 
+.addAlbum {
+    font-size: 1.1rem;
+}
+
 .info {
-    width: 500px;
+    width: 450px;
     display: inline-block;
 }
 
@@ -82,5 +63,14 @@
             width: 250px;
             height: 250px;
         }
+    }
+}
+
+@media only screen and (max-width: $mobile-width-limit) {
+    .column {
+        display: block;
+    };
+    .info {
+        width: 290px
     }
 }

--- a/web/frontend/src/AlbumPage/index.js
+++ b/web/frontend/src/AlbumPage/index.js
@@ -1,2 +1,2 @@
 
-export {default} from "./Component";
+export {default} from "./Container";

--- a/web/frontend/src/App/App.js
+++ b/web/frontend/src/App/App.js
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, {useState} from 'react';
 
 import styles from "./Style.scss";
+
+import classnames from "classnames";
 
 import Search from '../Search'
 import {Route, Redirect, Switch, Link, BrowserRouter} from "react-router-dom";
@@ -12,26 +14,53 @@ import ChannelPage from "../ChannelPage";
 import Queue from "../Queue";
 import Browse from "../Browse/Browse";
 import StatsPage from "../StatusPage";
-import CurrentAlbum from "../CurrentAlbum";
 import MPDConsole from "../MPDConsole/Component";
+import {mpdQuery} from "../mpd";
+import {useMediaQuery} from "react-responsive";
+import NavButton from "../NavButton";
+import VolDown from "../icons/vol_down.svg";
+import VolUp from "../icons/vol_up.svg";
 
 
 export default function App(props) {
+    const smallScreen = useMediaQuery({
+        query: '(max-width: 800px)',
+    });
+    const [drawerOpen, setDrawer] = useState(false);
+    const {volume} = props;
     const Nav = () => {
-        return <div className={styles.nav}>
-            <Link to="/web/search">Search</Link>
-            <Link to="/web/browse/genre">Browse</Link>
-            <Link to="/web/queue">Queue {props.queueCount ? ` (${props.queueCount})` : ""}</Link>
-            <Link to="/web/channels">Channels</Link>
-            <Link to="/web/stats">Settings {props.dbUpdating ? " (U)" : ""}</Link>
+        const cn = classnames({
+            [styles["root-nav"]]: true,
+            [styles.open]: !smallScreen || drawerOpen,
+        });
+        return <div className={cn} onClick={() => setDrawer(false)}><div onClick={ev => ev.stopPropagation()} className={styles.nav}>
+            {smallScreen && <div className={styles["nav-button-div"]}><NavButton light onClick={()=>setDrawer(false)}/></div>}
+            <Link onClick={() => setDrawer(false)} to="/web/search">Search</Link>
+            <Link onClick={() => setDrawer(false)} to="/web/browse/genre">Browse</Link>
+            <Link onClick={() => setDrawer(false)} to="/web/queue">Queue {props.queueCount ? ` (${props.queueCount})` : ""}</Link>
+            <Link onClick={() => setDrawer(false)} to="/web/channels">Channels</Link>
+            <Link onClick={() => setDrawer(false)} to="/web/stats">Settings {props.dbUpdating ? " (U)" : ""}</Link>
             <div className={styles.noConnection} style={{display: props.isConnected ? "none" : "block"}}>
                 Not Connected
             </div>
-            <CurrentAlbum cls={styles.currentAlbum}/>
-        </div>
+        </div></div>
     };
-    return <BrowserRouter><React.Fragment>
+    const volIconDim = {
+        height: 30,
+        width: 50,
+        viewBox: "0 150 250 250",
+    }
+    return <BrowserRouter><div id={styles["app-root"]}>
         <div id={styles["browser-root"]}>
+            {smallScreen && <span className={styles["root-nav-button"]}>
+                <NavButton onClick={()=>setDrawer(true)}/>
+                <span>{props.queueCount ? `Q: ${props.queueCount}`:""}</span>
+            </span>}
+            <div className={styles.volume}>
+                <button onClick={() => mpdQuery("volume -2")}><VolDown {...volIconDim}/></button>
+                <span><b>{volume}</b></span>
+                <button onClick={() => mpdQuery("volume +2")}><VolUp {...volIconDim}/></button>
+            </div>
             <Switch>
                 <Route exact path="/web" render={() => <Redirect to={'/web/search'}/>}/>
                 <Route path="/web/search" component={Search}/>
@@ -47,8 +76,8 @@ export default function App(props) {
                 <Route path="/web/console" component={MPDConsole}/>
             </Switch>
         </div>
-        <PlaybackControls/>
         <Nav/>
+        <PlaybackControls/>
         <Snackbar/>
-    </React.Fragment></BrowserRouter>
+    </div></BrowserRouter>
 }

--- a/web/frontend/src/App/Container.js
+++ b/web/frontend/src/App/Container.js
@@ -7,6 +7,7 @@ import _ from "lodash";
 const mapStateToProps = state => ({
     queueCount: state.queue.length,
     dbUpdating: !(_.isUndefined(state.playback.updating_db) || _.isNull(state.playback.updating_db)),
+    volume: state.playback.volume,
     isConnected: state.connected,
 });
 

--- a/web/frontend/src/App/Style.scss
+++ b/web/frontend/src/App/Style.scss
@@ -27,7 +27,11 @@ div.volume {
   display:inline-block;
   margin: 10px;
   vertical-align: middle;
+  font-size: 1.5rem;
 
+  > * {
+    vertical-align: middle;
+  }
   > button {
     margin: 0 5px;
   }

--- a/web/frontend/src/App/Style.scss
+++ b/web/frontend/src/App/Style.scss
@@ -17,6 +17,22 @@
   left:0;
 }
 
+.nav-button-div {
+  display: block;
+  text-align: left;
+  padding-left: 10px;
+}
+
+div.volume {
+  display:inline-block;
+  margin: 10px;
+  vertical-align: middle;
+
+  > button {
+    margin: 0 5px;
+  }
+}
+
 body {
   margin: 0;
   font-family: sans-serif;
@@ -31,9 +47,6 @@ div.nav {
   text-align: center;
   padding: 8px;
   box-sizing: border-box;
-  position: fixed;
-  top: 0;
-  left: 0;
   a {
     padding: 10px;
     display: block;
@@ -42,16 +55,59 @@ div.nav {
   }
 }
 
-div.nav, #browser-root {
-  display:inline-block;
-  vertical-align: top;
+.root-nav-button {
+  font-weight: bold;
+  > * {
+    margin-right: 10px;
+    vertical-align: middle;
+    display: inline-block;
+    font-size: 1.5rem;
+  }
 }
 
 #browser-root {
   /* Add padding-bottom to the browse window
   so content isn't covered by the playback bar */
-  padding: 10px 10px 100px $nav-bar-width + 20px;
+  padding: 10px 10px 150px $nav-bar-width + 20px;
 }
+
+.root-nav {
+  height: 100vh;
+  width: $nav-bar-width;
+  background: rgba(0, 0, 0, 0.7);
+  position: absolute;
+  display: none;
+
+  &.open {
+    display: block;
+  }
+}
+
+div.nav, #browser-root {
+  display: inline-block;
+  vertical-align: top;
+  position: absolute;
+}
+
+@media only screen and (max-width: $mobile-width-limit) {
+  .root-nav {
+    width: 100vw;
+  }
+  .root-nav.open {
+    display: block;
+  }
+
+  #browser-root {
+    padding-left: 20px
+  }
+}
+
+#app-root {
+  width: 100vw;
+  height: 100vh;
+  display: inline-block;
+}
+
 
 .fatal-error {
   text-align: center;

--- a/web/frontend/src/Browse/Style.scss
+++ b/web/frontend/src/Browse/Style.scss
@@ -10,8 +10,6 @@
     padding: 7px;
     border-radius: 5px;
     margin: 6px;
-    a {
-      color: $color-text-dark
-    }
+    font-size: 1.2rem;
   }
 }

--- a/web/frontend/src/CurrentAlbum/Component.js
+++ b/web/frontend/src/CurrentAlbum/Component.js
@@ -2,6 +2,8 @@ import React from "react";
 
 import {albumArtUrl} from "../urls";
 
+import styles from "./Style.scss"
+
 export default function CurrentAlbum(props) {
 
     const [err, setErr] = React.useState(false);
@@ -9,13 +11,15 @@ export default function CurrentAlbum(props) {
     const {playback, queue, cls} = props;
 
     if (!playback.hasOwnProperty("song"))
-        return <div/>
+        return <div className={styles.err}/>
 
     const src = albumArtUrl(queue[parseInt(playback.song)]);
-    return <img
+    return err ? <div className={styles.err} /> : <img
         src={err ? `/static/notfound.png` : src}
         alt={src}
         className={cls}
-        onError={() => setErr(true)}
+        onError={() => {
+            setErr(true)
+        }}
     />
 }

--- a/web/frontend/src/CurrentAlbum/Style.scss
+++ b/web/frontend/src/CurrentAlbum/Style.scss
@@ -1,0 +1,15 @@
+
+@import "../Vars";
+
+.err {
+  width: $status-bar-height;
+  height: $status-bar-height;
+  background: #2f2f2f;
+}
+
+@media only screen and (min-width: $mobile-width-limit) {
+  .err {
+    width: $status-bar-height-desktop;
+    height: $status-bar-height-desktop;
+  }
+}

--- a/web/frontend/src/Global.scss
+++ b/web/frontend/src/Global.scss
@@ -1,6 +1,29 @@
 
 @import "Vars.scss";
 
+button {
+  border-radius: 5px;
+  border: none;
+  padding: 5px 8px;
+  font-weight: bold;
+  color: $color-text-dark;
+  background: $color-button;
+
+  svg {
+    fill: $color-text-dark;
+  }
+
+  &:hover {
+    background: $color-text-dark;
+    color: $color-button;
+
+    svg {
+      fill: $color-button
+    }
+  }
+}
+
+
 a {
   text-decoration: none;
   color: $color-text-dark;

--- a/web/frontend/src/NavButton/Component.js
+++ b/web/frontend/src/NavButton/Component.js
@@ -1,0 +1,17 @@
+
+import React from "react";
+
+import classnames from "classnames";
+import styles from "./Style.scss";
+
+export default ({onClick, light}) => {
+    const cn = classnames({
+        [styles.root]: true,
+        [styles.light]: light,
+    });
+    return <button className={cn} onClick={onClick}>
+        <div className={styles["drawer-bar"]} />
+        <div className={styles["drawer-bar"]} />
+        <div className={styles["drawer-bar"]} />
+    </button>
+}

--- a/web/frontend/src/NavButton/Style.scss
+++ b/web/frontend/src/NavButton/Style.scss
@@ -1,0 +1,20 @@
+@import "../Vars";
+
+.root {
+  cursor: pointer;
+  width: 50px;
+  height: 50px;
+  display: inline-block;
+
+  &:hover {
+    background: $color-button;
+  }
+  > .drawer-bar {
+    height: 4px;
+    &:not(:first-child) {
+      margin-top: 8px;
+    }
+    background: $color-text-dark;
+  }
+}
+

--- a/web/frontend/src/NavButton/index.js
+++ b/web/frontend/src/NavButton/index.js
@@ -1,0 +1,1 @@
+export {default} from "./Component";

--- a/web/frontend/src/PlaybackControls/Component.js
+++ b/web/frontend/src/PlaybackControls/Component.js
@@ -5,8 +5,8 @@ import isNaN from "lodash/isNaN";
 import find from "lodash/find";
 
 import styles from "./Style.scss";
-import {albumArtUrl} from "../urls";
 
+import CurrentAlbum from "../CurrentAlbum";
 import PreviousIcon from "../icons/prev.svg"
 import NextIcon from "../icons/next.svg"
 import PlayIcon from "../icons/play.svg"
@@ -14,7 +14,7 @@ import PauseIcon from "../icons/pause.svg"
 import {mpdQuery} from "../mpd";
 
 const buttonIconDim = {
-    height: "100",
+    height: "70",
     width: "55",
 };
 
@@ -51,7 +51,7 @@ const useElapsedTime = (song, state, elapsed, duration) => {
             intervalRef.current = setInterval(routine, 1000);
         } else {
             clearInterval(intervalRef.current);
-            if (isEmpty(song)){
+            if (isEmpty(song)) {
                 elapsedRef.current = 0;
                 setElapsed(0);
             }
@@ -68,13 +68,15 @@ function ProgressBar({elapsed, duration}) {
         elapsed = 0.0;
         duration = 1.0;
     }
-    const pct = parseInt(100*elapsed / duration);
+    const pct = parseInt(100 * elapsed / duration);
 
-    return <div className={styles.progressBar}><div className={styles.inner} style={{width:`${pct}%`}}/></div>
+    return <div className={styles.progressBar}>
+        <div className={styles.inner} style={{width: `${pct}%`}}/>
+    </div>
 }
 
 export default function PlaybackControls({queue, playback}) {
-    const {state, volume, song} = playback;
+    const {state, song} = playback;
     const sendCmd = cmd => mpdQuery(cmd);
 
     const elapsed = parseFloat(playback.elapsed);
@@ -95,28 +97,27 @@ export default function PlaybackControls({queue, playback}) {
     );
 
     return <div className={styles.root}>
-        <div className={styles['now-playing']}>
-            <div className={styles["song-info"]}>
-                <h3>{title || "Nothing Playing"}</h3>
-                {album && <p><b>{album}</b> - {artist}</p>}
-                <ProgressBar duration={duration} elapsed={estElapsed}/>
+        <div className={styles.card}>
+            <ProgressBar duration={duration} elapsed={estElapsed}/>
+            <CurrentAlbum cls={styles["current-album"]}/>
+            <div className={styles['now-playing']}>
+                <div className={styles["song-info"]}>
+                    <h3>{title || "Nothing Playing"}</h3>
+                    {album && <p><b>{album}</b> - {artist}</p>}
+                </div>
             </div>
-        </div>
-        <div className={styles["playback-buttons"]}>
-            <button onClick={() => sendCmd('previous')}>
-                <PreviousIcon {...buttonIconDim}/>
-            </button>
-            <button onClick={() => sendCmd(msg.toLowerCase())}>
-                {msgIcon}
-            </button>
-            <button onClick={() => sendCmd('next')}>
-                <NextIcon {...buttonIconDim}/>
-            </button>
-        </div>
-        <div>
-            <button onClick={() => sendCmd("volume -2")}>Vol -</button>
-            <span>{volume}</span>
-            <button onClick={() => sendCmd("volume +2")}>Vol +</button>
+            <div className={styles["playback-buttons"]}>
+                <button onClick={() => sendCmd('previous')}>
+                    <PreviousIcon {...buttonIconDim}/>
+                </button>
+                <button onClick={() => sendCmd(msg.toLowerCase())}>
+                    {msgIcon}
+                </button>
+                <button onClick={() => sendCmd('next')}>
+                    <NextIcon {...buttonIconDim}/>
+                </button>
+            </div>
+            <div className={styles["last-child"]}/>
         </div>
     </div>
 }

--- a/web/frontend/src/PlaybackControls/Style.scss
+++ b/web/frontend/src/PlaybackControls/Style.scss
@@ -5,20 +5,38 @@
     position: fixed;
     bottom: 0;
     width: 100vw;
-    height: $status-bar-height;
-    background: $color-playback-bar;
-    padding-left: $nav-bar-width + 10px;
+    z-index: 9;
+    text-align: center;
+}
 
-    > * {
+.card {
+    text-align: left;
+    height: $status-bar-height+5px;
+    background: $color-playback-bar+5px;
+    display: inline-block;
+    margin: 10px;
+
+    > *:not(:first-child) {
         display: inline-block;
+        vertical-align: middle;
     }
+
+    > .last-child {
+        margin-right:15px;
+    }
+}
+
+.current-album {
+    max-height: $status-bar-height;
+    max-width: $status-bar-height;
 }
 
 .song-info {
     box-sizing: border-box;
-    display: inline-block;
+    display: none;
     padding: 0 15px 0 10px;
-    width: 400px;
+    width: 300px;
+    text-align: left;
 
     > * {
         white-space: nowrap;
@@ -50,20 +68,22 @@
 
     button {
         background: none;
-        border: none;
         vertical-align: middle;
         padding: 0 10px;
+    }
+}
 
-        svg {
-            fill: white;
-        }
+@media only screen and (min-width: $mobile-width-limit) {
+    .card {
+        height: $status-bar-height-desktop + 5px;
+    }
 
-        &:hover {
-            background: white;
+    .current-album {
+        max-height: $status-bar-height-desktop;
+        max-width: $status-bar-height-desktop;
+    }
 
-            svg {
-                fill: #25274d;
-            }
-        }
+    .song-info {
+        display: inline-block;
     }
 }

--- a/web/frontend/src/Queue/Style.scss
+++ b/web/frontend/src/Queue/Style.scss
@@ -4,29 +4,47 @@
 button {
     &.clearQueue, &.toggle, &.removeItem {
         border: none;
-        border-radius: 2px;
-        padding: 7px;
-        cursor: pointer;
-    }
-
-    &.clearQueue, &.toggle {
-        font-size: 1.1rem;
+        font-size: 1rem;
     }
 
     &.clearQueue {
         background: #b02c40;
         color: white;
         margin-right: 20px;
+
+        &:hover {
+            background: #900c20;
+            color: $color-text-dark;
+        }
     }
 
     &.toggle {
-        background: #bed4e1;
-        width: 156px;
+        width: 140px;
+        background: #666;
         margin-right: 3px;
-        color: black;
         &.enabled {
-            background: #3ae429;
+            background: #0c8b00;
+            &:hover {
+                color: $color-text-dark;
+                background: #004b00
+            }
         }
+    }
+}
+
+.songInfo {
+    width: 400px
+}
+
+@media only screen and (max-width: $mobile-width-limit) {
+    .songInfo {
+        width: auto;
+    }
+    .queueItem {
+        width: 100%;
+    }
+    .removeItem {
+        float: right;
     }
 }
 
@@ -45,6 +63,7 @@ button {
 
     &.selected {
         background: #0c8b00;
+
     }
 
     &:hover {
@@ -53,9 +72,6 @@ button {
     }
 }
 
-.songInfo {
-    width: 400px
-}
 
 .trackTitle {
     font-weight: bold;
@@ -68,9 +84,4 @@ button {
 .removeItem {
     background: $color-button;
     color: white;
-
-    &:hover {
-        background: $color-button-hover;
-        font-weight: bold;
-    }
 }

--- a/web/frontend/src/Search/Component.js
+++ b/web/frontend/src/Search/Component.js
@@ -91,7 +91,7 @@ export function Search({history, location}) {
             });
         }}><input
             placeholder="Search..."
-            size={42}
+            size={30}
             className={styles.mainInput}
             type="text"
             ref={inputRef}

--- a/web/frontend/src/Search/Style.scss
+++ b/web/frontend/src/Search/Style.scss
@@ -2,20 +2,29 @@
 @import "../Vars";
 
 .searchForm > * {
-    font-size: 30px;
+    font-size: 20px;
     background: $color-list-item;
     border: 2px solid $color-bg-nav;
     border-radius: 5px;
-    padding: 10px;
     outline:none;
     color: $color-text-dark;
     &.mainInput {
+        padding: 10px;
         &::placeholder {
             color: #d0d0d0;
         }
     }
     &.mainSubmit {
+        margin-left: 5px;
+        padding: 5px 8px;
         font-weight: bold;
+    }
+}
+
+@media only screen and (max-width: $mobile-width-limit) {
+    .searchForm > * {
+        font-size: 18px;
+        padding: 5px;
     }
 }
 

--- a/web/frontend/src/StatusPage/Component.js
+++ b/web/frontend/src/StatusPage/Component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {useMPDQuery, englishTimeStr} from "../urls";
 import classNames from "classnames";
 import styles from "./Styles.scss"
+import globalStyles from "../Global.scss";
 import {SocketContext} from "../socket";
 import {mpdQuery, objFromData} from "../mpd";
 import {Link} from "react-router-dom";
@@ -32,8 +33,7 @@ const SiteStats = stats => {
             <u>Sum of Song Times</u>:{'\u00A0'}
             {englishTimeStr(parseInt(stats.db_playtime))}</b>
         </span>
-
-        <h2>System</h2>
+        <div className={globalStyles.divider}/>
         <table>
             <tbody>
             <tr>
@@ -62,16 +62,18 @@ function StatusPage(props) {
     const updating = props.isUpdating;
 
     return <React.Fragment>
-        <h1>Status, Stats, Settings</h1>
+        <h1>System</h1>
         <Link to={"/web/console"}>MPD Console</Link>
         <div>
             <div className={classNames(styles.dbUpdate, {[styles.active]: updating})}>
                 Database Update: {updating ? "ON" : "OFF"}
             </div>
         </div>
-        <button onClick={()=>{mpdQuery("update")}} disabled={updating}>
+        <button onClick={()=>mpdQuery("update")} disabled={updating}>
             Start an Update
         </button>
+
+        <div className={globalStyles.divider}/>
 
         <SiteStats {...stats}/>
     </React.Fragment>

--- a/web/frontend/src/Vars.scss
+++ b/web/frontend/src/Vars.scss
@@ -7,8 +7,11 @@ $color-list-item: #3d3d3d;
 $color-playback-bar: #161616;
 $color-bg-nav: $color-playback-bar;
 
-$color-button: #101010;
+$color-button: #0e0e0e;
 $color-button-hover: #6b6b6b;
 
 $nav-bar-width: 180px;
-$status-bar-height: 100px;
+$status-bar-height: 70px;
+$status-bar-height-desktop: 100px;
+
+$mobile-width-limit: 800px;

--- a/web/frontend/src/icons/vol_down.svg
+++ b/web/frontend/src/icons/vol_down.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.0//EN' 'http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd'>
+<svg fill-opacity="1" xmlns:xlink="http://www.w3.org/1999/xlink" color-rendering="auto" color-interpolation="auto" text-rendering="auto" stroke="black" stroke-linecap="square" stroke-miterlimit="10" shape-rendering="auto" stroke-opacity="1" fill="black" stroke-dasharray="none" font-weight="normal" stroke-width="1" xmlns="http://www.w3.org/2000/svg" font-family="&apos;Dialog&apos;" font-style="normal" stroke-linejoin="miter" font-size="12" stroke-dashoffset="0" image-rendering="auto">
+  <defs id="genericDefs" />
+  <g>
+    <g>
+      <path d="M204.8906 275.7656 Q204.8906 318.375 176.0625 357.75 L165.6562 350.1562 Q191.9531 315 191.9531 275.7656 Q191.9531 237.2344 165.6562 201.375 L176.0625 193.7812 Q204.8906 233.1562 204.8906 275.7656 ZM136.125 378.1406 L69.8906 316.9688 L28.125 316.9688 L28.125 234.5625 L70.0312 234.5625 L136.125 173.5312 L136.125 378.1406 Z" stroke="none" />
+    </g>
+  </g>
+</svg>

--- a/web/frontend/src/icons/vol_up.svg
+++ b/web/frontend/src/icons/vol_up.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.0//EN' 'http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd'>
+<svg fill-opacity="1" xmlns:xlink="http://www.w3.org/1999/xlink" color-rendering="auto" color-interpolation="auto" text-rendering="auto" stroke="black" stroke-linecap="square" stroke-miterlimit="10" shape-rendering="auto" stroke-opacity="1" fill="black" stroke-dasharray="none" font-weight="normal" stroke-width="1" xmlns="http://www.w3.org/2000/svg" font-family="&apos;Dialog&apos;" font-style="normal" stroke-linejoin="miter" font-size="12" stroke-dashoffset="0" image-rendering="auto">
+  <!--Unicode Character 'SPEAKER WITH THREE SOUND WAVES' (U+1F50A)-->
+  <defs id="genericDefs" />
+  <g>
+    <g>
+      <path d="M266.7656 275.7656 Q266.7656 340.7344 222.8906 396.2812 L212.625 388.2656 Q253.8281 337.3594 253.8281 275.7656 Q253.8281 215.4375 212.7656 163.4062 L223.0312 155.3906 Q266.7656 210.9375 266.7656 275.7656 ZM235.8281 275.7656 Q235.8281 329.625 199.5469 377.0156 L189.2812 369.2812 Q222.8906 325.4062 222.8906 275.7656 Q222.8906 226.2656 189.2812 182.3906 L199.5469 174.6562 Q235.8281 221.0625 235.8281 275.7656 ZM204.8906 275.7656 Q204.8906 318.375 176.0625 357.75 L165.6562 350.1562 Q191.9531 315 191.9531 275.7656 Q191.9531 237.2344 165.6562 201.375 L176.0625 193.7812 Q204.8906 233.1562 204.8906 275.7656 ZM136.125 378.1406 L69.8906 316.9688 L28.125 316.9688 L28.125 234.5625 L70.0312 234.5625 L136.125 173.5312 L136.125 378.1406 Z" stroke="none" />
+    </g>
+  </g>
+</svg>

--- a/web/frontend/yarn.lock
+++ b/web/frontend/yarn.lock
@@ -2502,6 +2502,11 @@ css-loader@^2.1.0:
     postcss-value-parser "^3.3.0"
     schema-utils "^1.0.0"
 
+css-mediaquery@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
+  integrity sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -3625,6 +3630,11 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+hyphenate-style-name@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -4242,6 +4252,13 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+matchmediaquery@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.3.1.tgz#8247edc47e499ebb7c58f62a9ff9ccf5b815c6d7"
+  integrity sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==
+  dependencies:
+    css-mediaquery "^0.1.2"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -5237,6 +5254,16 @@ react-redux@^7.0.3:
     prop-types "^15.7.2"
     react-is "^16.9.0"
 
+react-responsive@^9.0.0-beta.4:
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-9.0.0-beta.4.tgz#90c1f1a4048971497ca9795068af6803eabc0ddb"
+  integrity sha512-jQSs5kIi38T39Ku98r8s75jM6JAaNEeVrHPHTrL2EYWuv8nusV3KRQcZZ4VlfwndIRedxmpb4T8FXA9ltlCFiw==
+  dependencies:
+    hyphenate-style-name "^1.0.0"
+    matchmediaquery "^0.3.0"
+    prop-types "^15.6.1"
+    shallow-equal "^1.2.1"
+
 react-router-dom@^5.1.2:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
@@ -5834,6 +5861,11 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
+
+shallow-equal@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
+  integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
 shebang-command@^1.2.0:
   version "1.2.0"

--- a/web/frontend/yarn.lock
+++ b/web/frontend/yarn.lock
@@ -5054,6 +5054,11 @@ postcss@^7.0.14, postcss@^7.0.5, postcss@^7.0.6:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+prettier@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+
 private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"


### PR DESCRIPTION
Includes:

- Responsive overhaul
    - On narrow screens, the side-nav will tuck away into a drawer, which can be opened with the new drawer button
    - Redesigned the playback bar to have a smaller footprint
    - moved volume control to the top of the page (next to the drawer button)
    - now playing info is hidden on small screens - only playback & album cover are shown.
    - progress bar is on the top border of the playback bar
- Button standardization
    - Tried to fit most buttons in the app under one color scheme & shape/profile