### PR TITLE
Bugfix: albums ending in question mark break the site

### DIFF
--- a/web/src/AlbumPage/Component.js
+++ b/web/src/AlbumPage/Component.js
@@ -27,6 +27,8 @@ function mostCommonValue(l, k) {
 }
 
 export default function AlbumPage({ album, albumartist }) {
+  album = decodeURIComponent(album);
+  albumartist = decodeURIComponent(albumartist);
   const { showSnackbar } = useContext(SnackbarContext);
   const { loaded, err, data } = useMPDQuery(
     `find albumartist "${albumartist}" album "${album}"`


### PR DESCRIPTION
Some pages don't properly url-encode album or albumartist when looking up album art or the album page. If an album or albumartist includes any characters like `#` or `?`, it will cause the url to be mis-parsed by the browser and break the site.