### PR TITLE
Frontend Fixes

### DIFF
--- a/web/src/AlbumPage/Component.js
+++ b/web/src/AlbumPage/Component.js
@@ -26,6 +26,15 @@ function mostCommonValue(l, k) {
   return maxBy(toPairs(counts), ([_, c]) => c);
 }
 
+function runTimeString(runTime) {
+	const runHours = Math.floor(runTime / 3600);
+	const runMinutes = Math.floor((runTime % 3600) / 60);
+
+	if (runHours > 0)
+		return `${runHours} hr ${runMinutes} min`
+	return `${runMinutes} min`
+}
+
 export default function AlbumPage({ album, albumartist }) {
   album = decodeURIComponent(album);
   albumartist = decodeURIComponent(albumartist);
@@ -44,12 +53,10 @@ export default function AlbumPage({ album, albumartist }) {
 
   // Calculate the duration of this album in hours & minutes
   const runTime = sumBy(tracks, (t) => parseInt(t.time));
-  const runHours = Math.floor(runTime / 3600);
-  const runMinutes = Math.floor((runTime % 3600) / 60);
 
   // If the tracks have different dates, choose the most common one.
-  const date = mostCommonValue(tracks, "date");
-  const genre = mostCommonValue(tracks, "genre");
+  const [date, _] = mostCommonValue(tracks, "date");
+  const [genre, __] = mostCommonValue(tracks, "genre");
 
   const albumAdd = () =>
     mpdQuery(`findadd album "${album}" albumartist "${albumartist}"`).then(() =>
@@ -70,8 +77,7 @@ export default function AlbumPage({ album, albumartist }) {
         <b>{albumartist}</b>
         {(date && ` - ${date}`) || ""}
         <br />
-        {(runHours && `${runHours} hr `) || ""}
-        {(runMinutes && `${runMinutes} min`) || ""}
+				{runTimeString(runTime)}
         <br />
         <i>Genre: {genre}</i>
         <br />

--- a/web/src/AlbumPage/Style.scss
+++ b/web/src/AlbumPage/Style.scss
@@ -13,10 +13,6 @@ $line-height: 45px;
   > .trackNum {
     line-height: $line-height;
   }
-  
-  > .time {
-    line-height: $line-height;
-  }
 
   > * {
     display: inline-block;

--- a/web/src/AlbumPage/Style.scss
+++ b/web/src/AlbumPage/Style.scss
@@ -1,13 +1,22 @@
 @import "../Vars";
 
+$line-height: 45px;
+
 .trackItem {
   padding: 6px;
-  height: 45px;
-  line-height: 45px;
+  height: $line-height;
   background: $color-list-item;
   border-radius: 5px;
   margin: 6px 0;
   position: relative;
+
+  > .trackNum {
+    line-height: $line-height;
+  }
+  
+  > .time {
+    line-height: $line-height;
+  }
 
   > * {
     display: inline-block;

--- a/web/src/ArtistPage/Component.js
+++ b/web/src/ArtistPage/Component.js
@@ -9,7 +9,7 @@ import urls from "../urls";
 
 export default function ArtistPage(props) {
   const { artist, history } = props;
-  const { data, loaded, err } = useMPDQuery(`find artist "${artist}"`);
+  const { data, loaded, err } = useMPDQuery(`find albumartist "${artist}"`);
   const [show, _] = React.useState(false);
 
   if (!loaded) return <div />;

--- a/web/src/Browse/Browse.js
+++ b/web/src/Browse/Browse.js
@@ -34,7 +34,7 @@ function GenrePage(props) {
   const genreName = decodeURIComponent(match.params.genre);
 
   const { loaded, err, data } = useMPDQuery(
-    `list artist genre \"${genreName}\"`
+    `list albumartist genre \"${genreName}\"`
   );
   if (!loaded) return <div />;
   if (err) {


### PR DESCRIPTION
### Browser
* Browse by Album Artist, not Artist

### Album Page Fixes
* In the bio, genre & date included a `,{number}` tail that should not be there
* When an album is multi-artist, The title & artist lines in each track item are drawn  to be 45px tall, causing the values to overflow.