### PR TITLE
BUGFIX: Artist page doesn't decode URL fields

### DIFF
--- a/web/src/ArtistPage/Component.js
+++ b/web/src/ArtistPage/Component.js
@@ -9,7 +9,7 @@ import urls from "../urls";
 
 export default function ArtistPage(props) {
   const { artistUnDecoded, history } = props;
-	const artist = decodeURIComponent(artistUnDecoded);
+  const artist = decodeURIComponent(artistUnDecoded);
   const { data, loaded, err } = useMPDQuery(`find albumartist "${artist}"`);
   const [show, _] = React.useState(false);
 

--- a/web/src/ArtistPage/Component.js
+++ b/web/src/ArtistPage/Component.js
@@ -8,7 +8,8 @@ import { albumListFromData } from "../mpd";
 import urls from "../urls";
 
 export default function ArtistPage(props) {
-  const { artist, history } = props;
+  const { artistUnDecoded, history } = props;
+	const artist = decodeURIComponent(artistUnDecoded);
   const { data, loaded, err } = useMPDQuery(`find albumartist "${artist}"`);
   const [show, _] = React.useState(false);
 

--- a/web/src/ArtistPage/Component.js
+++ b/web/src/ArtistPage/Component.js
@@ -8,7 +8,7 @@ import { albumListFromData } from "../mpd";
 import urls from "../urls";
 
 export default function ArtistPage(props) {
-  const { artistUnDecoded, history } = props;
+  const { artist: artistUnDecoded, history } = props;
   const artist = decodeURIComponent(artistUnDecoded);
   const { data, loaded, err } = useMPDQuery(`find albumartist "${artist}"`);
   const [show, _] = React.useState(false);


### PR DESCRIPTION
The frontend url-encodes ID3 tags to safely use them in URLs. So the artist page for "The Beatles" is `/web/artist/The%20Beatles`. For encoded fields with non-trivial characters (comma, ampersand), the browser or url router won't automatically decode those values. So `Emerson, Lake & Palmer` (`Emerson%2C%20Lake%20%26%20Palmer`) ended up as `Emerson%2C Lake %26 Palmer` in the frontend memory, which will match with nothing when searched for in MPD.

The fix is to include a decode step in the render step of the Artist page so that it queries the MPD backend with the correct value.