### PR TITLE
Overhaul Proxy events

### DIFF
--- a/mpd-web-proxy/Dockerfile
+++ b/mpd-web-proxy/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 ARG VERSION='development'
 
 COPY go.mod go.sum ./
+RUN go mod download
 COPY *.go ./
 COPY gpio/ ./gpio/
 COPY art/ ./art/

--- a/mpd-web-proxy/config.go
+++ b/mpd-web-proxy/config.go
@@ -4,9 +4,9 @@ import "os"
 
 var (
 	MpdAuthority string
-	PinFile string
-	BindAddr string
-	MusicDir string
+	PinFile      string
+	BindAddr     string
+	MusicDir     string
 )
 
 func init() {

--- a/mpd-web-proxy/events.go
+++ b/mpd-web-proxy/events.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,80 +17,113 @@ type EventType int
 const (
 	EventTypeUnset EventType = iota
 	EventTypePing
+	EventTypeServer
 	EventTypeMPD
 )
 
-// the MPDIdler continually calls the `idle` MPD 
-// command and sends idle events on the returned 
-// string channel.
-func startMPDIdler(mpd net.Conn) chan string {
-	eventC := make(chan string)
-	go func() {
-		slog.Debug("start MPD Idler")
-		defer slog.Debug("end MPD Idler")
-		defer close(eventC)
-		sc := bufio.NewScanner(mpd)
-		// MPD Header
-		sc.Scan()
-
-		for {
-			io.WriteString(mpd, "idle\n")
-			for sc.Scan() {
-				line := sc.Text()
-				if line == "OK" {
-					break
-				}
-				parts := strings.SplitN(line, ":", 2)
-				if len(parts) != 2 {
-					slog.Error(fmt.Sprintf("unexpected string: %s\n", line))
-					return
-				}
-				ev := strings.TrimSpace(parts[1])
-				slog.Debug(fmt.Sprint("sending event:", ev))
-				eventC <- ev
-			}
-			if err := sc.Err(); err != nil {
-				if _, ok := err.(*net.OpError); !ok {
-					slog.Error(fmt.Sprintf("unexpected error: %T %s\n", err, err))
-				}
-				return
-			}
-		}
-	}()
-	return eventC
-}
-
-// An Event is any asynchronous event 
-// that should be sent to a listening client.
 type Event struct {
-	Type EventType
-	Data string
+	Type    EventType
+	Payload string
 }
 
-// getEvents starts a goroutine which emits events
-// to send to the client. Events include:
-//   - any string sent on the provided string channel is sent as an MPDEvent
-//   - the emitter produces a "ping" event that clients can use as a heartbeat.
-// The emitter exits and closes the returned channel when the given context
-// is cancelled.
-func getEvents(ts chan string, ctx context.Context) chan Event {
+func (ev Event) SSEPayload() string {
+	var typ string
+	switch ev.Type {
+	case EventTypePing:
+		typ = "ping"
+	case EventTypeMPD:
+		typ = "mpd"
+	case EventTypeServer:
+		typ = "server"
+	default:
+		typ = "???"
+	}
+	var payload = ev.Payload
+	if payload == "" {
+		payload = "none"
+	}
+	return fmt.Sprintf("event: %s\ndata: %s\n\n", typ, payload)
+}
+
+func MPDIdler(tpc *Topic[Event]) {
+	oneRound := func() error {
+		slog.Info("start idler")
+		defer slog.Info("stop idler")
+		mpd, err := net.Dial("tcp", MpdAuthority)
+		if err != nil {
+			return err
+		}
+		defer mpd.Close()
+		tpc.Publish(Event{
+			Type:    EventTypeServer,
+			Payload: "mpd-connected",
+		})
+		return mpdIdle(mpd, tpc)
+	}
+	for {
+		err := oneRound()
+		tpc.Publish(Event{
+			Type:    EventTypeServer,
+			Payload: "mpd-connection-lost",
+		})
+		slog.Error("idler exited", "error", err)
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// the MPDIdler continually calls the `idle` MPD
+// command and sends idle events on the returned
+// string channel.
+func mpdIdle(mpd net.Conn, tpc *Topic[Event]) error {
+	rd := bufio.NewReader(mpd)
+	_, err := rd.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	for {
+		_, err := io.WriteString(mpd, "idle\n")
+		if err != nil {
+			return err
+		}
+		for {
+			line, err := rd.ReadString('\n')
+			if err != nil {
+				return err
+			}
+			line = strings.TrimSpace(line)
+			if line == "OK" {
+				break
+			}
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) != 2 {
+				return errors.New("MPD returned strange response: " + line)
+			}
+			ev := strings.TrimSpace(parts[1])
+			tpc.Publish(Event{
+				Type:    EventTypeMPD,
+				Payload: ev,
+			})
+		}
+	}
+}
+
+func getEvents(tpc *Topic[Event], ctx context.Context) chan Event {
 	ret := make(chan Event)
-	ticker := time.NewTicker(5 * time.Second)
 	go func() {
 		defer close(ret)
+		ts := tpc.Subscribe()
+		defer tpc.Unsubscribe(ts)
+		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 		ret <- Event{Type: EventTypePing}
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case <-ticker.C:
 				ret <- Event{Type: EventTypePing}
 			case t := <-ts:
-				if t == "" {
-					return
-				}
-				ret <- Event{Type: EventTypeMPD, Data: t}
-			case <-ctx.Done():
-				return
+				ret <- t
 			}
 		}
 	}()

--- a/mpd-web-proxy/gpio/arm.go
+++ b/mpd-web-proxy/gpio/arm.go
@@ -1,4 +1,4 @@
-//go:build arm
+//go:build arm || arm64
 package gpio
 
 import (

--- a/mpd-web-proxy/logging.go
+++ b/mpd-web-proxy/logging.go
@@ -10,7 +10,8 @@ import (
 // the status code returned from an HTTP handler.
 //
 // XXX - this is a barebones handler that does not implement
-//       flushing, hijacking or any of the other http interfaces.
+//
+//	flushing, hijacking or any of the other http interfaces.
 type StatusCaptureRW struct {
 	http.ResponseWriter
 	status int
@@ -30,17 +31,16 @@ func loggingMiddleware(next http.Handler) http.Handler {
 		sc := NewStatusCaptureRW(rw)
 		next.ServeHTTP(sc, req)
 
-		line := fmt.Sprintf("%s %s %d", req.RemoteAddr, req.URL.String(), sc.status) 
+		line := fmt.Sprintf("%s %s %d", req.RemoteAddr, req.URL.String(), sc.status)
 
 		switch sc.status / 100 {
-			case 3, 4:
-				slog.Warn(line)
-			case 5:
-				slog.Error(line)
-			default:
-				slog.Info(line)
+		case 3, 4:
+			slog.Warn(line)
+		case 5:
+			slog.Error(line)
+		default:
+			slog.Info(line)
 		}
 	}
 	return http.HandlerFunc(f)
 }
-

--- a/mpd-web-proxy/topic.go
+++ b/mpd-web-proxy/topic.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"log/slog"
+	"sync"
+)
+
+type Topic[T any] struct {
+	mu          *sync.Mutex
+	subscribers map[chan<- T]struct{}
+}
+
+func NewTopic[T any]() *Topic[T] {
+	return &Topic[T]{
+		mu:          new(sync.Mutex),
+		subscribers: make(map[chan<- T]struct{}),
+	}
+}
+
+func (t *Topic[T]) Subscribe() chan T {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	myChan := make(chan T)
+	t.subscribers[myChan] = struct{}{}
+	slog.Debug("client subscribed", "chan", myChan)
+	return myChan
+}
+
+func (t *Topic[T]) Unsubscribe(myChan chan<- T) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	slog.Debug("client unsubscribed", "chan", myChan)
+	delete(t.subscribers, myChan)
+	close(myChan)
+}
+
+func (t *Topic[T]) Publish(ev T) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	slog.Debug("publish event", "event", ev, "to", t.subscribers)
+	for c := range t.subscribers {
+		c <- ev
+	}
+}

--- a/web/src/App/App.js
+++ b/web/src/App/App.js
@@ -21,7 +21,7 @@ import FunPage from "../Fun";
 import NavButton from "../NavButton";
 import VolDown from "../icons/vol_down.svg";
 import VolUp from "../icons/vol_up.svg";
-import { ConnectionContext } from "./Context";
+import { ConnectionContext, NotConnectedMsg } from "./Context";
 import { QueueContext } from "../Queue/Context";
 import { PlaybackContext } from "../PlaybackControls/Context";
 
@@ -63,9 +63,9 @@ export default function App() {
           <Link_ to="/web/stats">Settings {dbUpdating ? " (U)" : ""}</Link_>
           <div
             className={styles.noConnection}
-            style={{ display: connected ? "none" : "block" }}
+            style={{ display: connected === 0 ? "none" : "block" }}
           >
-            Not Connected
+						{NotConnectedMsg(connected)}
           </div>
         </div>
       </div>

--- a/web/src/App/Context.js
+++ b/web/src/App/Context.js
@@ -1,6 +1,18 @@
 import React, { useState, createContext } from "react";
 
-const InitialConnectedState = false;
+export const Connected = 0;
+export const MPDNotConnected = 1;
+export const ProxyNotConnected = 2;
+
+const InitialConnectedState = ProxyNotConnected;
+
+export function NotConnectedMsg(lvl) {
+	if (lvl === ProxyNotConnected)
+		return "Proxy Connection Lost";
+	if (lvl === MPDNotConnected) 
+		return "No MPD Connection";
+	return null;
+}
 
 export const ConnectionContext = createContext({
   connected: InitialConnectedState,

--- a/web/src/StatusPage/Component.js
+++ b/web/src/StatusPage/Component.js
@@ -8,6 +8,7 @@ import globalStyles from "../Global.scss";
 import { isDBUpdating, mpdQuery, objFromData } from "../mpd";
 import { Link } from "react-router-dom";
 import { PlaybackContext } from "../PlaybackControls/Context";
+import { ConnectionContext, MPDNotConnected, NotConnectedMsg, ProxyNotConnected } from "../App/Context";
 
 function SiteStats() {
   const { data, loaded, err } = useMPDQuery("stats");
@@ -90,8 +91,12 @@ function ComponentVersions() {
 	</>
 }
 
+const Connected = <span style={{fontWeight: "bold", color: "green"}}>Connected</span>
+const NotConnected = <span style={{fontWeight: "bold", color: "red"}}>Not Connected</span>
+
 export default function StatusPage() {
 
+	const { connected } = useContext(ConnectionContext);
   const { playback } = useContext(PlaybackContext);
   const updating = isDBUpdating(playback);
 
@@ -103,7 +108,7 @@ export default function StatusPage() {
 					style={{marginBottom: "20px"}}
 					className={globalStyles.globalButton}
 				>
-						 {"[$ _ ]"} Go To MPD Console 
+					{"[$ _ ]"} Go To MPD Console 
 				</div>
 		  </Link>
       <div>
@@ -118,9 +123,26 @@ export default function StatusPage() {
       </button>
 
       <div className={globalStyles.divider} />
+			<h2>Connection Status</h2>
+			<div
+				className={classNames(styles.dbUpdate, { 
+					[styles.active]: connected < ProxyNotConnected,
+					[styles.error]: connected >= ProxyNotConnected,
+				})}
+			>
+			Proxy: {connected < ProxyNotConnected ? "Connected" : "Not Connected"}
+			</div><br/><br/>
+			<div
+				className={classNames(styles.dbUpdate, { 
+					[styles.active]: connected < MPDNotConnected,
+					[styles.error]: connected >= MPDNotConnected,
+				})}
+			>
+			MPD: {connected < MPDNotConnected ? "Connected" : "Not Connected"}
+			</div>
+      <div className={globalStyles.divider} />
       <ComponentVersions/>
       <div className={globalStyles.divider} />
-
       <SiteStats />
     </React.Fragment>
   );

--- a/web/src/StatusPage/Styles.scss
+++ b/web/src/StatusPage/Styles.scss
@@ -4,10 +4,14 @@
   background: #2b2b2b;
   color: white;
   display: inline-block;
+  font-weight: bold;
 
   &.active {
-    background: #3a7734;
-    color: black;
+    background: #096a00;
+  }
+
+  &.error {
+    background: #b02c40;
   }
 }
 
@@ -20,3 +24,4 @@
   font-weight: bold;
   color: red;
 }
+

--- a/web/src/mpd.js
+++ b/web/src/mpd.js
@@ -132,6 +132,5 @@ export function startMpdWatcher(
 		} else if (data === "mpd-connection-lost") {
 			setConnection(MPDNotConnected);
 		}
-
 	});
 }

--- a/web/src/mpd.js
+++ b/web/src/mpd.js
@@ -1,3 +1,6 @@
+
+import {Connected, ProxyNotConnected, MPDNotConnected} from "./App/Context";
+
 /**
  * Utilities issuing MPD commands/queries via `/ws/mpd/command`
  */
@@ -107,11 +110,10 @@ export function startMpdWatcher(
   showSnackbar
 ) {
   const es = new EventSource("/go/events");
-  es.onerror = () => setConnection(false);
-  es.onopen = () => setConnection(true);
-  es.addEventListener("ping", () => setConnection(true));
-  es.onmessage = function (ev) {
-    setConnection(true);
+  es.onerror = () => setConnection(ProxyNotConnected);
+  es.onopen = () => setConnection(Connected);
+	es.addEventListener("mpd", ev => {
+    setConnection(Connected);
     const changed = ev.data;
     if (STATUS_UPDATE_TYPES.includes(changed)) {
       pullPlaybackInfo().then(setPlayback);
@@ -123,5 +125,13 @@ export function startMpdWatcher(
       pullPlaybackInfo().then(setPlayback);
       showSnackbar("database update");
     }
-  };
+	});
+	es.addEventListener("server", ({data}) => {
+		if (data === "mpd-connected") {
+			setConnection(Connected);
+		} else if (data === "mpd-connection-lost") {
+			setConnection(MPDNotConnected);
+		}
+
+	});
 }


### PR DESCRIPTION
## Bug Fix: Runaway Goroutines
The `startMPDIdler` function has a bug which causes the idler goroutine to enter an infinite loop if its connection to MPD is broken. The issue is an incorrectly-used scanner; in the case that MPD closes the connection, `sc.Scan()` returns false but doesn't error. The Idler only exits on error, so it enters an infinite loop of calling sc.Scan() on a closed socket.

### Fixes
* Switch to a `bufio.Reader` for error-handling at the time that the socket read occurs, as well as direct handling of `io.EOF`.
* Add error-handling code where there was none previously, returning from the idler if any socket error occurs
* Wrap the original idler logic in another function that manages dropped connections and re-attempts to connect to MPD
* Include a `Sleep` call to throttle the attempts to reconnect.

## New Event Pub/Sub System
Create a new `Topic` type which supports single-topic publish/subscribe between goroutines.
Receivers can subscribe and unsubscribe from the topic, and publishers can create events on
the topic with `Publish`. `Topic` is thread-safe.

Refactored the `/go/events` endpoint to utilize a pub/sub topic to receive updates from the server.
Each SSE client subscribes to the topic, and the new "idler" goroutine publishes changes on the other end.

## Refactor: Single idler, multiple listeners
Currently, each SSE client uses its own connection to the MPD server when using the "idle" command.
This PR refactors the event system using a pub/sub mechanism:
* Only one goroutine maintains an "idle" connection with the MPD socket.
* The goroutine receives server updates and publishes them on a channel-based pub/sub topic
* Any open SSE clients will subscribe to the event topic and receive any published events.

## Frontend Changes
* Updated the event source object to handle the refactored event system
* New events for mpd connecting/disconnecting
* New connection status bubbles on the Settings page