### PR TITLE
account for possible padding bytes at end of tag

### DIFF
--- a/mpd-web-proxy/art/id3.go
+++ b/mpd-web-proxy/art/id3.go
@@ -87,6 +87,9 @@ func ReadV3Frame(rd *bufio.Reader, fr *V3Frame) error {
 		return err
 	}
 	frameType := string(frameHeader[:4])
+	if frameHeader[0] == 0 && frameHeader[1] == 0 && frameHeader[2] == 0 && frameHeader[3] == 0 {
+		return ErrNoAPIC
+	}
 	frameSize := binary.BigEndian.Uint32(frameHeader[4:8])
 	frameFlags := (uint16(frameHeader[8]) << 8) | uint16(frameHeader[9])
 	frameData := make([]byte, frameSize)
@@ -102,13 +105,14 @@ func ReadV3Frame(rd *bufio.Reader, fr *V3Frame) error {
 
 func ApicFrame(data []byte) (string, []byte, error) {
 	ptr := 1
-	for ; ptr < len(data) && data[ptr] != 0; ptr++ {}
+	for ; ptr < len(data) && data[ptr] != 0; ptr++ {
+	}
 	if ptr == len(data) {
 		return "", nil, ErrMalformedID3
 	}
 	mimeType := string(data[1:ptr])
 	ptr += 2
-	for ; ptr < len(data) && data[ptr] != 0; ptr++ {}
+	for ; ptr < len(data) && data[ptr] != 0; ptr++ {
+	}
 	return mimeType, data[ptr+1:], nil
 }
-


### PR DESCRIPTION
According to the id3v2 spec (https://id3.org/id3v2.3.0#id3v2_overview):

> It is permitted to include padding after all the final frame (at the end of the ID3 tag), making the size of all the frames together smaller than the size given in the head of the tag. A possible purpose of this padding is to allow for adding a few additional frames or enlarge existing frames within the tag without having to rewrite the entire file. The value of the padding bytes must be $00.

The v3 ID3 reader expects all bytes in the allotted frame to include non-zero frames, which is not always the case. This change accounts for possible padding by stopping early if it finds that the four bytes for the type is `\x00\x00\x00\x00`.