### PR TITLE
Additional Hotfixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         FRONTEND_VERSION: '${{ github.ref_name }}'
 
     - name: Collect Artifacts
-      run: tar -czf frontend.tar.gz ./web/dist/* ./web/static/index.html
+      run: tar -czf frontend.tar.gz ./web/dist/* ./web/static/*
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4

--- a/web/src/CurrentAlbum/Component.js
+++ b/web/src/CurrentAlbum/Component.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 
 import urls from "../urls";
 
@@ -12,14 +12,19 @@ export default function CurrentAlbum({ cls }) {
   const { playback } = useContext(PlaybackContext);
   const { queue } = useContext(QueueContext);
 
-  if (!playback.hasOwnProperty("song") || queue.length === 0) return <div className={styles.err} />;
+	// If the song changes over, reset error state
+	useEffect(() => {setErr(false)}, [playback.playlist, playback.song]);
 
-  const src = urls.albumArtUrl(queue[parseInt(playback.song)]);
+  if (!playback.hasOwnProperty("song") || queue.length === 0) return <div className={styles.err} />;
+	const alb = queue[parseInt(playback.song)];
+	if (alb.albumartist === undefined)
+		alb.albumaritst = alb.artist;
+  const src = urls.albumArtUrl(alb);
   return err ? (
     <div className={styles.err} />
   ) : (
     <img
-      src={err ? `/static/notfound.png` : src}
+      src={src}
       alt={src}
       className={cls}
       onError={() => {


### PR DESCRIPTION
Additional fixes that missed the previous release:
* Include the "missing art" asset for real this time
* the album art in the "current playing" bar didn't have the artist fallback fix

New fix:
* The "Now Playing" album art would remain in an "error" state even after a song plays with available album art. Updated the now-playing album art to reset its error state when the song changes over.